### PR TITLE
fix: remove debug/safety checks

### DIFF
--- a/.github/workflows/trunk-check.yaml
+++ b/.github/workflows/trunk-check.yaml
@@ -11,7 +11,6 @@ jobs:
   check:
     name: ${{ fromJSON(inputs.client_payload).checkJobName }}
     runs-on: [ubuntu-latest]
-    if: startsWith(fromJSON(inputs.client_payload).version, '0.')
     concurrency:
       group: ${{ fromJSON(inputs.client_payload).concurrencyGroup }}
       cancel-in-progress: true


### PR DESCRIPTION
* there's no reason to log `clientPayload` separately for users
* `concurrencyGroup` should always be set; if it's not, that's a bug on our side
* there's also no need to guard against launching the `check` job using `clientPayload.version`