### PR TITLE
Revert "fix: remove debug/safety checks"

### DIFF
--- a/.github/workflows/trunk-check.yaml
+++ b/.github/workflows/trunk-check.yaml
@@ -11,8 +11,9 @@ jobs:
   check:
     name: ${{ fromJSON(inputs.client_payload).checkJobName }}
     runs-on: [ubuntu-latest]
+    if: startsWith(fromJSON(inputs.client_payload).version, '0.')
     concurrency:
-      group: ${{ fromJSON(inputs.client_payload).concurrencyGroup }}
+      group: ${{ fromJSON(inputs.client_payload).concurrencyGroup || github.run_id }}
       cancel-in-progress: true
 
     steps:
@@ -21,6 +22,11 @@ jobs:
         run: |
           echo "::add-mask::$(jq '.inputs.client_payload | fromjson | .githubToken' $GITHUB_EVENT_PATH)"
           echo "::add-mask::$(jq '.inputs.client_payload | fromjson | .token'       $GITHUB_EVENT_PATH)"
+
+      - name: Log input
+        shell: bash
+        run: |
+          jq '.inputs.client_payload | fromjson' $GITHUB_EVENT_PATH
 
       - name: Trunk Check
         uses: trunk-io/trunk-action@v1


### PR DESCRIPTION
Reverts trunk-io/.trunk#2

We'll want to roll this forward at some point, but staging needs to get re-released first.