### PR TITLE
chore: clean up trunk-check.yaml

### DIFF
--- a/.github/workflows/trunk-check.yaml
+++ b/.github/workflows/trunk-check.yaml
@@ -1,5 +1,5 @@
 name: Trunk Check
-run-name: ${{ fromJSON(inputs.payload).checkJobRunName }}
+run-name: ${{ fromJSON(inputs.payload).checkWorkflowRunName }}
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
* remove references to deprecated `workflow_dispatch` inputs
* remove `jobs.check.if` - there's no purpose to it; `trunk-io/trunk-action` will eventually have to become a meta-action for dispatching to other actions
* require `concurrencyGroup` to always be specified; remove the `github.run_id` fallback
* allow reading the `.trunk` repo in this workflow - this will allow us to store common trunk configuration here, if we ever want to