### PR TITLE
feat: pin to trunk-io/trunk-action at v1 instead of main

### DIFF
--- a/.github/workflows/trunk-check.yaml
+++ b/.github/workflows/trunk-check.yaml
@@ -20,6 +20,6 @@ jobs:
 
     steps:
       - name: Trunk Check
-        uses: trunk-io/trunk-action@main
+        uses: trunk-io/trunk-action@v1
         with:
           check-mode: payload


### PR DESCRIPTION
Pinning to `main` made sense while we were dogfood testing, but for customers it should be pinned to `v1`.